### PR TITLE
Iv overhaul

### DIFF
--- a/benchmarks/roofline.jsh
+++ b/benchmarks/roofline.jsh
@@ -1,6 +1,7 @@
 #!/usr/local/bin/js
-assertEq(isSimdAvaialble(), true);
+assertEq(isSimdAvailable(), true);
 load('../lib/benchmark.js');
+load('../bin/vectorize.browser.js');
 
 Array.prototype.fill = function (val) {
     for (var i = 0; i < this.length; i++) {
@@ -31,6 +32,9 @@ function vector (args, n) {
         args[i+3] = tmp.w;
     }
 }
+
+console.log = function (args) { };
+vectorizedScalar = vectorize.me(scalar);
 
 var samples = [
 { e: 2500, n: 4000 },
@@ -64,5 +68,6 @@ for (i in samples) {
     var arr = new Array(sample.e).fill(0);
     var b1 = new Benchmark(function () { scalar(arr, sample.n) }); b1.run();
     var b2 = new Benchmark(function () { vector(arr, sample.n) }); b2.run();
-    print(sample.e + ', ' + sample.n + ', ' + (b1.times.period * 1000) + ', ' + (b2.times.period * 1000));
+    var b3 = new Benchmark(function () { vectorizedScalar(arr, sample.n) }); b3.run();
+    print(sample.e + ', ' + sample.n + ', ' + (b1.times.period * 1000) + ', ' + (b2.times.period * 1000) + ', ' + (b3.times.period * 1000));
 }

--- a/lib/qunit-print.css
+++ b/lib/qunit-print.css
@@ -2,26 +2,20 @@
     margin-top: 10px;
     background-color: #FFF;
     border-radius: 5px;
+    padding: 10px;
     color: #000;
 }
 
-#qunit-tests .qunit-messages table {
-    border: 0;
-    border-collapse: separate;
-    border-spacing: 5px;
-    width: 100%;
-}
-
-#qunit-tests .qunit-messages table td {
-    min-width: 33%;
-}
-
 #qunit-tests .qunit-messages pre {
-    display: inline-block;
-    height: 100%;
+    margin-bottom: 10px;
+    padding: 5px;
+    width: auto;
     background-color: #EEE;
     border-radius: 5px;
-    padding: 5px;
     white-space: pre-wrap;
+}
+
+#qunit-tests .qunit-messages pre:last-child {
+    margin-bottom: 0px;
 }
 

--- a/lib/qunit-print.css
+++ b/lib/qunit-print.css
@@ -1,0 +1,27 @@
+#qunit-tests .qunit-messages {
+    margin-top: 10px;
+    background-color: #FFF;
+    border-radius: 5px;
+    color: #000;
+}
+
+#qunit-tests .qunit-messages table {
+    border: 0;
+    border-collapse: separate;
+    border-spacing: 5px;
+    width: 100%;
+}
+
+#qunit-tests .qunit-messages table td {
+    min-width: 33%;
+}
+
+#qunit-tests .qunit-messages pre {
+    display: inline-block;
+    height: 100%;
+    background-color: #EEE;
+    border-radius: 5px;
+    padding: 5px;
+    white-space: pre-wrap;
+}
+

--- a/lib/qunit-print.js
+++ b/lib/qunit-print.js
@@ -1,0 +1,29 @@
+QUnit.testStart(function (details) {
+    QUnit.messages = "";   
+});
+
+QUnit.testDone(function (details) {
+    var id = '#qunit-test-output-' + details.testId;
+
+    // Add our messages.
+    $(id).append("<div class='qunit-messages'>" + QUnit.messages + "</div>");
+    
+    // If there were no failures, start out hidden.
+    if (details.failed === 0) {
+        $(id + ' > .qunit-messages').addClass('qunit-collapsed');
+    }
+
+    // When the title is clicked, toggle the collapsed class.
+    $(id + ' > strong').click(function (ev) { 
+        $(id + ' > .qunit-messages').toggleClass('qunit-collapsed') 
+    });
+   
+    // Pretty print the new code.
+    prettyPrint();
+});
+
+QUnit.extend (QUnit, {
+    print: function (msg) {
+        QUnit.messages += msg;
+    }
+});

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -1,6 +1,6 @@
 tests.push({
     name: 'Vector Add Literal',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [1, 2, 3, 4, 5, 6, 7, 8],
     fn: function fn (args) {
         for (var i = 0; i < args.length; i++) {
             args[i] = args[i] + 1;
@@ -11,7 +11,7 @@ tests.push({
 
 tests.push({
     name: 'Vector Add Identifier',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [1, 2, 3, 4, 5, 6, 7, 8],
     fn: function fn (args) {
         var x = 2;
         for (var i = 0; i < args.length; i++) {
@@ -37,7 +37,7 @@ tests.push({
 
 tests.push({
     name: 'Assignment Foo',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [1, 2, 3, 4, 5, 6, 7, 8],
     fn: function fn (args) {
         
         for (var i = 0; i < args.length; i++) {
@@ -53,7 +53,7 @@ tests.push({
 
 tests.push({
     name: 'Assignment Ops',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [1, 2, 3, 4, 5, 6, 7, 8],
     fn: function fn (args) {
         for (var i = 0; i < args.length; i++) {
             args[i] += 3;
@@ -67,7 +67,7 @@ tests.push({
 
 tests.push({
     name: 'Recursive Index',
-    args: { args1: [0, 0, 7, 7, 4, 4, 0, 0], args2: [ 0, 1, 2, 3, 4, 5, 6, 7 ] },
+    args: { args1: [0, 0, 7, 7, 4, 4, 0, 0], args2: [ 1, 2, 3, 4, 5, 6, 7, 8 ] },
     fn: function fn (args) {
         var a = args.arg1;
         var b = args.arg2;
@@ -81,7 +81,7 @@ tests.push({
 
 tests.push({
     name: 'Recursive Index Op',
-    args: { args1: [0, 0, 6, 6, 4, 4, 0, 0], args2: [ 0, 1, 2, 3, 4, 5, 6, 7 ] },
+    args: { args1: [0, 0, 6, 6, 4, 4, 0, 0], args2: [ 1, 2, 3, 4, 5, 6, 7, 8 ] },
     fn: function fn (args) {
         var a = args.arg1;
         var b = args.arg2;
@@ -95,7 +95,7 @@ tests.push({
 
 tests.push({
     name: 'Recursive Index Op Var',
-    args: { args1: [0, 0, 2, 2, 4, 4, 0, 0], args2: [ 0, 1, 2, 3, 4, 5, 6, 7 ] },
+    args: { args1: [0, 0, 2, 2, 4, 4, 0, 0], args2: [ 1, 2, 3, 4, 5, 6, 7, 8 ] },
     fn: function fn (args) {
         var a = args.arg1;
         var b = args.arg2;
@@ -109,8 +109,24 @@ tests.push({
 });
 
 tests.push({
+    // This likely cannot be supported since we won't be able to determine
+    // dependencies, but we might as well be able to do it!
+    name: 'Recursive Index Assign',
+    args: { args1: [1, 0, 4, 7, 5, 6, 3, 2], args2: [ 1, 2, 3, 4, 5, 6, 7, 8 ] },
+    fn: function fn (args) {
+        var a = args.arg1;
+        var b = args.arg2;
+        var c = [];
+        for (var i = 0; i < args.length; i++) {
+            c[a[i]] = b[i];
+        }
+        return c;
+    }
+});
+
+tests.push({
     name: 'Assignment Foo Two',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [ 1, 2, 3, 4, 5, 6, 7, 8 ],
     fn: function fn (args) {
         var x;
         for (var i = 0; i < args.length; i++) {
@@ -122,7 +138,7 @@ tests.push({
 
 tests.push({
     name: 'Hidden Assignment',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [ 1, 2, 3, 4, 5, 6, 7, 8 ],
     fn: function fn (args) {
         for (var i = 0; i < args.length; i++) {
             var x = args[i];
@@ -135,7 +151,7 @@ tests.push({
 
 tests.push({
     name: 'Sequences',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [ 1, 2, 3, 4, 5, 6, 7, 8 ],
     fn: function fn (args) {
         for (var i = 0; i < args.length; i++) {
             var x = (args[i] = 3, y = 2, 4);
@@ -149,7 +165,7 @@ tests.push({
 
 tests.push({
     name: 'IV != i',
-    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    args: [ 1, 2, 3, 4, 5, 6, 7, 8 ],
     fn: function fn (args) {
         for (var j = 0; j < args.length; j++) {
             args[j] = args[j] + 1;

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -80,6 +80,35 @@ tests.push({
 });
 
 tests.push({
+    name: 'Recursive Index Op',
+    args: { args1: [0, 0, 6, 6, 4, 4, 0, 0], args2: [ 0, 1, 2, 3, 4, 5, 6, 7 ] },
+    fn: function fn (args) {
+        var a = args.arg1;
+        var b = args.arg2;
+        var c = [];
+        for (var i = 0; i < args.length; i++) {
+            c[i] = b[a[i] + 1];
+        }
+        return c;
+    }
+});
+
+tests.push({
+    name: 'Recursive Index Op Var',
+    args: { args1: [0, 0, 2, 2, 4, 4, 0, 0], args2: [ 0, 1, 2, 3, 4, 5, 6, 7 ] },
+    fn: function fn (args) {
+        var a = args.arg1;
+        var b = args.arg2;
+        var c = [];
+        for (var i = 0; i < args.length; i++) {
+            var x = 3;
+            c[i] = b[a[i] + x];
+        }
+        return c;
+    }
+});
+
+tests.push({
     name: 'Assignment Foo Two',
     args: [0, 1, 2, 3, 4, 5, 6, 7],
     fn: function fn (args) {

--- a/tests/fail.js
+++ b/tests/fail.js
@@ -75,3 +75,16 @@ tests.push({
         return sum;
     }
 });
+
+tests.push({
+    name: 'Inner Loop Iterations',
+    args: [0, 1, 2, 3, 4, 5, 6, 7],
+    fn: function fn (args) {
+        for (var i = 0; i < args.length; i++) {
+            for (var j = 0; j < i; j++) {
+                args[i] += j;
+            }
+        } 
+        return args;
+    }   
+});

--- a/tests/moderate.js
+++ b/tests/moderate.js
@@ -25,31 +25,39 @@ tests.push({
 });
 
 tests.push({
-    name: 'Benchmark Test Nested Loops IV',
-    args: new Array(100),
+    name: 'Index Arithmetic',
+    args: new Array(100).fill(0),
     fn: function fn (args) {
         for (var i = 0; i < args.length; i++) {
-            var tmp = args[i];
-            for (var j = 0; j < 1000; j++) {
-                tmp += j;
-            }
-            args[i] = tmp;
+            var x = i;
+            var y = x + 2;
+            var z = i * y;
+            args[i] = z;
         }
         return args;
     }
 });
 
 tests.push({
-    name: 'Benchmark Test Nested Loops Constant',
-    args: new Array(100),
+    name: 'Complex LValue',
+    args: new Array(100).fill(0),
+    fn: function fn (args) {
+        var obj = { prop: args };
+        for (var i = 0; i < args.length; i++) {
+            obj.prop[i] = 2 * obj.prop[i];
+        }
+        return obj.prop;
+    }
+});
+
+tests.push({
+    name: 'Nothing-a-do-index',
+    args: new Array(100).fill(0),
     fn: function fn (args) {
         for (var i = 0; i < args.length; i++) {
-            var tmp = args[i];
-            for (var j = 0; j < 1000; j++) {
-                tmp += 1;
-            }
-            args[i] = tmp;
-        }
+            i + 2 - 1;
+            args[i] = 4;
+        }   
         return args;
     }
 });

--- a/tests/tests.tpl
+++ b/tests/tests.tpl
@@ -35,10 +35,8 @@
                 try {
                     var scalarFn = test.fn;
                     var vectorFn = vectorize.me(test.fn);
-                    QUnit.print("<table><tr>");
-                    QUnit.print("<td><pre class='prettyprint'>" + scalarFn + "</pre></td>");
-                    QUnit.print("<td><pre class='prettyprint'>" + vectorFn + "</pre></td>");
-                    QUnit.print("</tr></table>");
+                    QUnit.print("<pre class='prettyprint'>" + scalarFn + "</pre>");
+                    QUnit.print("<pre class='prettyprint'>" + vectorFn + "</pre>");
                     var args = test.args;
                     assert.deepEqual(vectorFn(clone(args)), scalarFn(clone(args)));
                 } catch (err) {

--- a/tests/tests.tpl
+++ b/tests/tests.tpl
@@ -4,18 +4,21 @@
     <meta charset="utf-8">
     <title>Vectorize.js Tests</title>
     <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.17.1.css">
+    <link rel="stylesheet" href="https://google-code-prettify.googlecode.com/svn/loader/prettify.css">
+    <link rel="stylesheet" href="../lib/qunit-print.css">
     <style>
         .test-diff {
-            visibility: hidden;
-            height: 0px;
-            position: absolute;
+            display: none;
         }
     </style>
 </head>
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
+    <script src="http://code.jquery.com/jquery-1.11.2.min.js"></script>
     <script src="http://code.jquery.com/qunit/qunit-1.17.1.js"></script>
+    <script src="https://google-code-prettify.googlecode.com/svn/loader/prettify.js"></script>
+    <script src="../lib/qunit-print.js"></script>
     <script src="../lib/simd.js"></script>
     <script src="../bin/vectorize.browser.js"></script>
     <script>
@@ -32,6 +35,10 @@
                 try {
                     var scalarFn = test.fn;
                     var vectorFn = vectorize.me(test.fn);
+                    QUnit.print("<table><tr>");
+                    QUnit.print("<td><pre class='prettyprint'>" + scalarFn + "</pre></td>");
+                    QUnit.print("<td><pre class='prettyprint'>" + vectorFn + "</pre></td>");
+                    QUnit.print("</tr></table>");
                     var args = test.args;
                     assert.deepEqual(vectorFn(clone(args)), scalarFn(clone(args)));
                 } catch (err) {

--- a/util.js
+++ b/util.js
@@ -68,10 +68,11 @@ util = (function(){
         };
     }
 
-    util.block = function (stmts) {
+    util.block = function (stmts, needed) {
         return {
             type: 'BlockStatement',
-            body: stmts
+            body: stmts,
+            needed: needed // This indicates whether we'll remove it in post processing
         };
     }
 

--- a/vectorize.js
+++ b/vectorize.js
@@ -106,7 +106,7 @@ vectorize = (function() {
         for (var i = 0; i < vectorWidth; i++) {
             var accessor = vectorAccessors[i];
             var read = util.property(util.ident(vector), accessor);
-            var write = util.membership(util.ident(arr), util.property(idxs, accessor));
+            var write = util.membership(util.ident(arr), util.property(idxs, accessor), true);
             writes[i] = util.assignment(write, read);
         }
         return util.block(writes, false);


### PR DESCRIPTION
Modifies the way induction variables are handled for efficiency reasons. 

Now the IV is not blindly thrown into a vector and accessed through that but rather used directly when constructing vectors. 
